### PR TITLE
Modify typo of constant name: `AmbigousOption` -> `AmbiguousOption`

### DIFF
--- a/lib/rexical/rexcmd.rb
+++ b/lib/rexical/rexcmd.rb
@@ -85,7 +85,7 @@ EOT
             "#{@cmd}: #{name} given twice" if @opt.key? name
         @opt[name]  =  arg.empty? ? true : arg
       end
-    rescue GetoptLong::AmbigousOption, GetoptLong::InvalidOption,
+    rescue GetoptLong::AmbiguousOption, GetoptLong::InvalidOption,
            GetoptLong::MissingArgument, GetoptLong::NeedlessArgument
       usage $!.message
     end

--- a/test/rex-20060125.rb
+++ b/test/rex-20060125.rb
@@ -91,7 +91,7 @@ def get_options
           "#{$cmd}: #{name} given twice" if opt.key? name
       opt[name]  =  arg.empty? ? true : arg
     end
-  rescue GetoptLong::AmbigousOption, GetoptLong::InvalidOption,
+  rescue GetoptLong::AmbiguousOption, GetoptLong::InvalidOption,
          GetoptLong::MissingArgument, GetoptLong::NeedlessArgument
     usage 1, $!.message
   end

--- a/test/rex-20060511.rb
+++ b/test/rex-20060511.rb
@@ -89,7 +89,7 @@ class RexRunner
             "#{@cmd}: #{name} given twice" if @opt.key? name
         @opt[name]  =  arg.empty? ? true : arg
       end
-    rescue GetoptLong::AmbigousOption, GetoptLong::InvalidOption,
+    rescue GetoptLong::AmbiguousOption, GetoptLong::InvalidOption,
            GetoptLong::MissingArgument, GetoptLong::NeedlessArgument
       usage $!.message
     end


### PR DESCRIPTION
I fixed the constant name `GetoptLong::AmbigousOption` to `GetoptLong::AmbiguousOption`.

I noticed this error when I run `rex` command with a wrong option.

```rb
$ rex --version
rex version 1.0.7

$ rex --hogehoge
/Users/user/.rbenv/gems/3.1.0/gems/rexical-1.0.7/lib/rexical/rexcmd.rb:88:in `rescue in initialize': uninitialized constant GetoptLong::AmbigousOption (NameError)

    rescue GetoptLong::AmbigousOption, GetoptLong::InvalidOption,
                     ^^^^^^^^^^^^^^^^
Did you mean?  GetoptLong::AmbiguousOption
	from /Users/user/.rbenv/gems/3.1.0/gems/rexical-1.0.7/lib/rexical/rexcmd.rb:82:in `initialize'
	from /Users/user/.rbenv/gems/3.1.0/gems/rexical-1.0.7/bin/rex:18:in `new'
	from /Users/user/.rbenv/gems/3.1.0/gems/rexical-1.0.7/bin/rex:18:in `<top (required)>'
	from /Users/user/.rbenv/gems/3.1.0/bin/rex:25:in `load'
	from /Users/user/.rbenv/gems/3.1.0/bin/rex:25:in `<main>'
/Users/user/.rbenv/versions/3.1.0/lib/ruby/3.1.0/getoptlong.rb:398:in `set_error': unrecognized option `--hogehoge' (GetoptLong::InvalidOption)
	from /Users/user/.rbenv/versions/3.1.0/lib/ruby/3.1.0/getoptlong.rb:505:in `get'
	from /Users/user/.rbenv/versions/3.1.0/lib/ruby/3.1.0/getoptlong.rb:606:in `block in each'
	from /Users/user/.rbenv/versions/3.1.0/lib/ruby/3.1.0/getoptlong.rb:605:in `loop'
	from /Users/user/.rbenv/versions/3.1.0/lib/ruby/3.1.0/getoptlong.rb:605:in `each'
	from /Users/user/.rbenv/gems/3.1.0/gems/rexical-1.0.7/lib/rexical/rexcmd.rb:83:in `initialize'
	from /Users/user/.rbenv/gems/3.1.0/gems/rexical-1.0.7/bin/rex:18:in `new'
	from /Users/user/.rbenv/gems/3.1.0/gems/rexical-1.0.7/bin/rex:18:in `<top (required)>'
	from /Users/user/.rbenv/gems/3.1.0/bin/rex:25:in `load'
	from /Users/user/.rbenv/gems/3.1.0/bin/rex:25:in `<main>'
```